### PR TITLE
[CI/CD] Setting up GitHub Action for building and publishing container to GitHub registry

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,5 +1,5 @@
 name: Docker
-
+working-directory: frontend
 on:
   push:
     # Publish `master` as Docker `latest` image.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,72 @@
+name: Docker
+
+on:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+
+  # Run tests for any PRs.
+  pull_request:
+
+env:
+  IMAGE_NAME: corrections-frontend
+
+jobs:
+  # Run tests.
+  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run tests
+        run: |
+          if [ -f docker-compose.test.yml ]; then
+            docker-compose --file docker-compose.test.yml build
+            docker-compose --file docker-compose.test.yml run sut
+          else
+            docker build . --file Dockerfile
+          fi
+
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+    # Ensure test job passes before pushing image.
+    needs: test
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+
+      - name: Log into GitHub Container Registry
+      # TODO: Create a PAT with `read:packages` and `write:packages` scopes and save it as an Actions secret `CR_PAT`
+        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push image to GitHub Container Registry
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,5 +1,5 @@
 name: Docker
-working-directory: frontend
+
 on:
   push:
     # Publish `master` as Docker `latest` image.
@@ -20,8 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
       - name: Run tests
+        working-directory: frontend
         run: |
           if [ -f docker-compose.test.yml ]; then
             docker-compose --file docker-compose.test.yml build
@@ -43,10 +43,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build image
+        working-directory: frontend
         run: docker build . --file Dockerfile --tag $IMAGE_NAME
 
       - name: Log into GitHub Container Registry
-      # TODO: Create a PAT with `read:packages` and `write:packages` scopes and save it as an Actions secret `CR_PAT`
         run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push image to GitHub Container Registry


### PR DESCRIPTION
# Summary
Related to #44 
Setting up GitHub Actions on the repo, only current action is to build the frontend image and publish it to the GitHub Container Registry.

**NOTE**: We require a Secret to be created for this repository called `CR_PAT` that contains a Personal Access Token (PAT) that a maintainer must create on the repo. The maintainer (like @hasankhan) can use a PAT and paste it's value for the value of the `CR_PAT` secret. It requires the `write:packages` scope for this workflow to succeed.

## What was done
- adding the YAML file to build and publish container to registry, got template when seeing up the workflow on my own repository, [see blog post here on container registry announcement](https://github.blog/2020-09-01-introducing-github-container-registry/)
  - ran successfully in my fork, [can see the package/container page here (I had to make it public, was private so that must be the default configuration)](https://github.com/users/tanjinP/packages/container/corrections-frontend/103018)

## What is next?
- We can build out the images for the `backend` if need be (seems like its a lambda so should be a straightforward way of testing/setting up)
- We can also make a `docker-compose.test.yml` as seen in the example, for now we hit that `else` condition but food for thought


I would like to work with the docker images more on my local to help guide next steps (unless maintainer(s) have suggestions).
